### PR TITLE
set version 0.7.2+jimdo1 to current master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+statsd (0.7.2+jimdo1) unstable; urgency=low
+
+  * master branch as of 17.02.2016
+  * debian build was broken in 0.7.2
+
+ -- Daniel Bonkowski <bonko@jimdo.com> Mi, 17 Feb 2016 11:23:00 +022
+
 statsd (0.7.2) unstable; urgency=low
 
   * Align version number to git tag versions


### PR DESCRIPTION
in order to get debian build working

No idea if statsd is working, though.

but we need this only for testing (I hope)
